### PR TITLE
Improve new replay parsing by optimizing metadata extraction

### DIFF
--- a/src/parsers/new/NewROFLParser.ts
+++ b/src/parsers/new/NewROFLParser.ts
@@ -1,17 +1,16 @@
 import { RawMetadata } from "../../types";
-import { Metadata } from "../../core/Metadata";
+import { Metadata } from "../../core";
 import { Parser } from "../Parser";
 
 /**
  * `NewROFLParser` is a class that extends the `Parser` abstract base class.
  * It is used to parse a ROFL file and extract its metadata.
+ * This class is specifically designed to handle the new format of ROFL files.
  * 
- * @property {number[]} signature - The signature of the ROFL file.
- * @property {number[]} pattern - The pattern used to locate the metadata in the ROFL file.
+ * @property {number} metadataSizeLength - The length of the metadata size field in bytes.
  */
 export class NewROFLParser extends Parser {
-    private static readonly signature: number[] = [0x52, 0x49, 0x4F, 0x54, 0x02, 0x00, 0x75, 0x1C, 0x08, 0xCD, 0x20, 0x99, 0xF8, 0x1C, 0x0E];
-    private static readonly pattern: number[] = [0x7B, 0x22, 0x67, 0x61, 0x6D, 0x65, 0x4C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x22];
+    private readonly metadataSizeLength: number = 4;
 
     /**
      * Creates a new instance of the NewROFLParser.
@@ -24,18 +23,16 @@ export class NewROFLParser extends Parser {
 
     /**
      * Parses the data and returns the metadata of the ROFL file.
-     * It locates the metadata in the data using the pattern, then parses the metadata.
+     * It locates the metadata in the data by calculating its position based on the metadata size field.
+     * It then extracts the metadata, parses it as JSON, and returns it as a `Metadata` object.
      *
      * @returns {Metadata} The metadata of the ROFL file.
      */
     public parse(): Metadata {
-        const pattern: Buffer = Buffer.from(NewROFLParser.pattern);
-        const position: number = this.data.indexOf(pattern);
-
-        if (position === -1)
-            throw new Error(`Metadata not found in the file`);
-
-        const rawMetadata: Buffer = this.data.subarray(position, this.data.length - 4);
+        const metadataLengthPosition: number = this.data.length - this.metadataSizeLength;
+        const metadataLength: number = this.data.subarray(metadataLengthPosition, this.data.length).readUInt32LE(0);
+        const metadataPosition: number = (this.data.length - metadataLength) - this.metadataSizeLength;
+        const rawMetadata: Buffer = this.data.subarray(metadataPosition, this.data.length - this.metadataSizeLength);
         const metadata: RawMetadata = JSON.parse(rawMetadata.toString());
 
         return new Metadata(metadata);


### PR DESCRIPTION
Instead of searching for the metadata start pattern, we now utilize the last 4 bytes of the file, which represent the size of the metadata.