### PR TITLE
Fix/unsupported version error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rofl-parser.js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.1.0` to `1.1.1`.

### Improvements to `determineParser` Method:
* [`src/core/ROFLReader.ts`](diffhunk://#diff-24d2cc66bfc3b6817dae6d38693c25da55317f8d2a71cf0d5f9285cefbb19fcdL47-R67): Modified the regex pattern to handle one or two digits for the minor version and added logic to trim trailing periods from the version string.
* [`src/core/ROFLReader.ts`](diffhunk://#diff-24d2cc66bfc3b6817dae6d38693c25da55317f8d2a71cf0d5f9285cefbb19fcdL47-R67): Added error logging and handling for unsupported ROFL versions, specifically for version `14.10`.
* [`src/core/ROFLReader.ts`](diffhunk://#diff-24d2cc66bfc3b6817dae6d38693c25da55317f8d2a71cf0d5f9285cefbb19fcdL47-R67): Improved the parser selection logic by parsing the major and minor version numbers and using them to determine the appropriate parser.